### PR TITLE
Ad Listeners could override each other

### DIFF
--- a/extras/src/com/mopub/mobileads/VungleInterstitial.java
+++ b/extras/src/com/mopub/mobileads/VungleInterstitial.java
@@ -56,7 +56,9 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
 
         // init clears the event listener.
         mVunglePub.init(context, appId);
-        mVunglePub.setEventListeners(this);
+        
+		resetListeners();
+		
         if (mVunglePub.isAdPlayable()) {
             Log.d("MoPub", "Vungle interstitial ad successfully loaded.");
             mCustomEventInterstitialListener.onInterstitialLoaded();
@@ -65,9 +67,17 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
             mCustomEventInterstitialListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
         }
     }
+	
+	protected void resetListeners(){
+		//	Because Interstital / Rewarded can be loaded at same time, override listener when executing calls on a specific ad type
+		//	Otherwise MoPub will get confused and will stop showing rewarded videos in this session
+		mVunglePub.setEventListeners(this);
+	}
 
     @Override
     protected void showInterstitial() {
+		resetListeners();
+		
         if (mVunglePub.isAdPlayable()) {
             mVunglePub.playAd();
         } else {

--- a/extras/src/com/mopub/mobileads/VungleRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/VungleRewardedVideo.java
@@ -75,6 +75,12 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
     protected String getAdNetworkId() {
         return VUNGLE_AD_NETWORK_CONSTANT;
     }
+	
+	protected void resetListeners(){
+		//	Because Interstital / Rewarded can be loaded at same time, override listener when executing calls on a specific ad type
+		//	Otherwise MoPub will get confused and will stop showing rewarded videos in this session
+		sVunglePub.setEventListeners(sVungleListener);
+	}
 
     @Override
     protected boolean checkAndInitializeSdk(@NonNull final Activity launcherActivity,
@@ -94,7 +100,9 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
     protected void loadWithSdkInitialized(@NonNull final Activity activity, @NonNull final Map<String, Object> localExtras, @NonNull final Map<String, String> serverExtras) throws Exception {
         String appId = serverExtras.containsKey(APP_ID_KEY) ? serverExtras.get(APP_ID_KEY) : DEFAULT_VUNGLE_APP_ID;
         sVunglePub.init(activity, appId);
-        sVunglePub.setEventListeners(sVungleListener);
+        
+		resetListeners();
+		
         Object adUnitObject = localExtras.get(DataKeys.AD_UNIT_ID_KEY);
         if (adUnitObject instanceof String) {
             mAdUnitId = (String) adUnitObject;
@@ -123,6 +131,8 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
 
     @Override
     protected void showVideo() {
+		resetListeners();
+		
         final AdConfig adConfig = new AdConfig();
         adConfig.setIncentivized(true);
         setUpMediationSettingsForRequest(adConfig);


### PR DESCRIPTION
Vungle adapters when loaded Rewarded and Interstial at the same time
would override listener on SDK, resulting in incorrect callbacks. Since
Mopub v4.9 they introduced guards for requesting mulitple rewarded ad
type, and wrong callbacks from Vungle would succesfully kill rewarded
ads support in that session, until user kills the app / game.

How to repro (using Mopub sample project):
1. Load interstial ad .
2. Load rewarded ad.
3. Show interstital ad.
4. Notice rewarded callback will triggered.

Next time when you try to load rewarded, you will be blocked by message
from mopub:
"Did not queue rewarded video request for ad unit XXXXXXXXXXX. The video
is already showing. "